### PR TITLE
Fix log redirection and make overusage script executable

### DIFF
--- a/overusage_notice_post.sh
+++ b/overusage_notice_post.sh
@@ -6,20 +6,19 @@
 # Inputs from DA
 USER="$username"
 EMAIL="$email"
-LIMIT_MB="$QUOTALIMITGIG"
-USAGE_MB="$QUOTAUSAGEGIG"
+LIMIT_GB="$QUOTALIMITGIG"
+USAGE_GB="$QUOTAUSAGEGIG"
 
 # Optional: Log
-echo "$(date): $USER exceeded quota. Used ${USAGE_MB}MB / Limit ${LIMIT_MB}MB" >> /var/log/da_overusage.log
-
+echo "$(date): $USER exceeded quota. Used ${USAGE_GB}GB / Limit ${LIMIT_GB}GB" >> /var/log/da_overusage.log
 # Send email to admin/reseller
-mail -s "Disk Quota Alert: $USER exceeded ${LIMIT_MB}MB" admin@example.com <<EOF
+mail -s "Disk Quota Alert: $USER exceeded ${LIMIT_GB}GB" admin@example.com <<EOF
 User: $USER
 Email: $EMAIL
 
 Disk usage exceeded:
-Limit: ${LIMIT_MB} MB
-Current Usage: ${USAGE_MB} MB
+Limit: ${LIMIT_GB} GB
+Current Usage: ${USAGE_GB} GB
 
 Please take appropriate action.
 EOF


### PR DESCRIPTION
## Summary
- keep the log write on one line in `overusage_notice_post.sh`
- make the overusage script executable
- use GB units for quota values

## Testing
- `bash -n overusage_notice_post.sh`


------
https://chatgpt.com/codex/tasks/task_e_68754af665a0832eb0a30cdbe346eb7a